### PR TITLE
feat: deploy script allows to pass env variables for contract addresses

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -61,9 +61,11 @@ seth send "${RWA_JOIN}" 'deny(address)' "${ETH_FROM}"
 [[ -z "RWA_INPUT_CONDUIT" ]] && RWA_INPUT_CONDUIT=$(dapp create RwaInputConduit "${MCD_GOV}" "${MCD_DAI}" "${RWA_URN}")
 
 # price it
-MIP21_LIQUIDATION_ORACLE=$(dapp create RwaLiquidationOracle "${MCD_VAT}" "${MCD_VOW}")
-seth send "${MIP21_LIQUIDATION_ORACLE}" 'rely(address)' "${MCD_PAUSE_PROXY}"
-seth send "${MIP21_LIQUIDATION_ORACLE}" 'deny(address)' "${ETH_FROM}"
+if [ ! -n "$MIP21_LIQUIDATION_ORACLE" ]; then
+    MIP21_LIQUIDATION_ORACLE=$(dapp create RwaLiquidationOracle "${MCD_VAT}" "${MCD_VOW}")
+    seth send "${MIP21_LIQUIDATION_ORACLE}" 'rely(address)' "${MCD_PAUSE_PROXY}"
+    seth send "${MIP21_LIQUIDATION_ORACLE}" 'deny(address)' "${ETH_FROM}"
+fi
 
 # print it
 echo "OPERATOR: ${OPERATOR}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,7 +15,7 @@ export ETH_GAS=6000000
 SYMBOL="RWA001"
 LETTER="A"
 ILK="${SYMBOL}-${LETTER}"
-OPERATOR="0xD23beB204328D7337e3d2Fb9F150501fDC633B0e"
+[[ -z "OPERATOR" ]] && OPERATOR="0xD23beB204328D7337e3d2Fb9F150501fDC633B0e"
 
 # kovan only
 TRUST1="0xda0fab060e6cc7b1C0AA105d29Bd50D71f036711"
@@ -31,13 +31,16 @@ RWA_TOKEN=$(dapp create RwaToken)
 seth send "${RWA_TOKEN}" 'transfer(address,uint256)' "$OPERATOR" $(seth --to-wei 1.0 ether)
 
 # route it
-RWA_OUTPUT_CONDUIT=$(dapp create RwaOutputConduit "${MCD_GOV}" "${MCD_DAI}")
-seth send "${RWA_OUTPUT_CONDUIT}" 'rely(address)' "${MCD_PAUSE_PROXY}"
-if [ "$1" == "kovan" ]; then
-    seth send "${RWA_OUTPUT_CONDUIT}" 'kiss(address)' "${TRUST1}"
-    seth send "${RWA_OUTPUT_CONDUIT}" 'kiss(address)' "${TRUST2}"
+[[ -z "$RWA_OUTPUT_CONDUIT" ]] && RWA_OUTPUT_CONDUIT=$(dapp create RwaOutputConduit "${MCD_GOV}" "${MCD_DAI}")
+
+if [ "$RWA_OUTPUT_CONDUIT" != "$OPERATOR" ]; then
+    seth send "${RWA_OUTPUT_CONDUIT}" 'rely(address)' "${MCD_PAUSE_PROXY}"
+    if [ "$1" == "kovan" ]; then
+        seth send "${RWA_OUTPUT_CONDUIT}" 'kiss(address)' "${TRUST1}"
+        seth send "${RWA_OUTPUT_CONDUIT}" 'kiss(address)' "${TRUST2}"
+    fi
+    seth send "${RWA_OUTPUT_CONDUIT}" 'deny(address)' "${ETH_FROM}"
 fi
-seth send "${RWA_OUTPUT_CONDUIT}" 'deny(address)' "${ETH_FROM}"
 
 # join it
 RWA_JOIN=$(dapp create AuthGemJoin "${MCD_VAT}" "${ILK_ENCODED}" "${RWA_TOKEN}")
@@ -55,7 +58,7 @@ seth send "${RWA_JOIN}" 'rely(address)' "${RWA_URN}"
 seth send "${RWA_JOIN}" 'deny(address)' "${ETH_FROM}"
 
 # connect it
-RWA_INPUT_CONDUIT=$(dapp create RwaInputConduit "${MCD_GOV}" "${MCD_DAI}" "${RWA_URN}")
+[[ -z "RWA_INPUT_CONDUIT" ]] && RWA_INPUT_CONDUIT=$(dapp create RwaInputConduit "${MCD_GOV}" "${MCD_DAI}" "${RWA_URN}")
 
 # price it
 MIP21_LIQUIDATION_ORACLE=$(dapp create RwaLiquidationOracle "${MCD_VAT}" "${MCD_VOW}")


### PR DESCRIPTION
**Summary**
This PR enables the deploy script to be re-used to deploy MIP21 for the MIP22 `mgr` contract.
In the  MIP22 case the  `mgr` contract acts as the RWA_OUTPUT_CONDUIT, OPERATOR and RWA_INPUT_CONDUIT contract.

**Changes**
- checks if contract address environment variable is already defined for
    - RWA_OUTPUT_CONDUIT
    - OPERATOR
    - RWA_INPUT_CONDUIT
- permissions on RWA_OUTPUT_CONDUIT are only given if OPERATOR is unequal RWA_OUTPUT_CONDUIT

**Example Deploy Call for Kovan**
mrg contract on kovan: `0x27efe12d1bede473960859e85375fab75f4c9ffa`

```shell
OPERATOR=0x27efe12d1bede473960859e85375fab75f4c9ffa RWA_OUTPUT_CONDUIT=0x27efe12d1bede473960859e85375fab75f4c9ffa RWA_INPUT_CONDUIT=0x27efe12d1bede473960859e85375fab75f4c9ffa ./scripts/deploy.sh kovan
```