### PR TITLE
Rm dss interfaces

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "lib/ds-math"]
 	path = lib/ds-math
 	url = https://github.com/dapphub/ds-math
-[submodule "lib/dss-interfaces"]
-	path = lib/dss-interfaces
-	url = https://github.com/makerdao/dss-interfaces.git
 [submodule "lib/dss-gem-joins"]
 	path = lib/dss-gem-joins
 	url = https://github.com/makerdao/dss-gem-joins

--- a/src/RwaConduit.sol
+++ b/src/RwaConduit.sol
@@ -20,7 +20,7 @@
 
 pragma solidity 0.6.12;
 
-import "dss-interfaces/dapp/DSTokenAbstract.sol";
+import "./interfaces/DSTokenAbstract.sol";
 
 contract RwaInputConduit {
     DSTokenAbstract public gov;

--- a/src/RwaLiquidationOracle.sol
+++ b/src/RwaLiquidationOracle.sol
@@ -20,7 +20,7 @@
 
 pragma solidity 0.6.12;
 
-import "dss-interfaces/dss/VatAbstract.sol";
+import "./interfaces/VatAbstract.sol";
 import "ds-value/value.sol";
 
 contract RwaLiquidationOracle {

--- a/src/RwaSpell.sol
+++ b/src/RwaSpell.sol
@@ -20,13 +20,13 @@
 
 pragma solidity 0.6.12;
 
-import "dss-interfaces/dss/VatAbstract.sol";
-import "dss-interfaces/dapp/DSPauseAbstract.sol";
-import "dss-interfaces/dss/JugAbstract.sol";
-import "dss-interfaces/dss/SpotAbstract.sol";
-import "dss-interfaces/dss/GemJoinAbstract.sol";
-import "dss-interfaces/dapp/DSTokenAbstract.sol";
-import "dss-interfaces/dss/ChainlogAbstract.sol";
+import "./interfaces/VatAbstract.sol";
+import "./interfaces/DSPauseAbstract.sol";
+import "./interfaces/JugAbstract.sol";
+import "./interfaces/SpotAbstract.sol";
+import "./interfaces/GemJoinAbstract.sol";
+import "./interfaces/DSTokenAbstract.sol";
+import "./interfaces/ChainlogAbstract.sol";
 
 interface RwaLiquidationLike {
     function wards(address) external returns (uint256);

--- a/src/RwaUrn.sol
+++ b/src/RwaUrn.sol
@@ -20,12 +20,12 @@
 
 pragma solidity 0.6.12;
 
-import "dss-interfaces/dss/VatAbstract.sol";
-import "dss-interfaces/dss/JugAbstract.sol";
-import "dss-interfaces/dapp/DSTokenAbstract.sol";
-import "dss-interfaces/dss/GemJoinAbstract.sol";
-import "dss-interfaces/dss/DaiJoinAbstract.sol";
-import "dss-interfaces/dss/DaiAbstract.sol";
+import "./interfaces/VatAbstract.sol";
+import "./interfaces/JugAbstract.sol";
+import "./interfaces/DSTokenAbstract.sol";
+import "./interfaces/GemJoinAbstract.sol";
+import "./interfaces/DaiJoinAbstract.sol";
+import "./interfaces/DaiAbstract.sol";
 
 contract RwaUrn {
     // --- auth ---

--- a/src/interfaces/CatAbstract.sol
+++ b/src/interfaces/CatAbstract.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/cat.sol
+interface CatAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function box() external view returns (uint256);
+    function litter() external view returns (uint256);
+    function ilks(bytes32) external view returns (address, uint256, uint256);
+    function live() external view returns (uint256);
+    function vat() external view returns (address);
+    function vow() external view returns (address);
+    function file(bytes32, address) external;
+    function file(bytes32, uint256) external;
+    function file(bytes32, bytes32, uint256) external;
+    function file(bytes32, bytes32, address) external;
+    function bite(bytes32, address) external returns (uint256);
+    function claw(uint256) external;
+    function cage() external;
+}

--- a/src/interfaces/ChainlogAbstract.sol
+++ b/src/interfaces/ChainlogAbstract.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss-chain-log
+interface ChainlogAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function keys() external view returns (bytes32[] memory);
+    function version() external view returns (string memory);
+    function ipfs() external view returns (string memory);
+    function setVersion(string calldata) external;
+    function setSha256sum(string calldata) external;
+    function setIPFS(string calldata) external;
+    function setAddress(bytes32,address) external;
+    function removeAddress(bytes32) external;
+    function count() external view returns (uint256);
+    function get(uint256) external view returns (bytes32,address);
+    function list() external view returns (bytes32[] memory);
+    function getAddress(bytes32) external view returns (address);
+}
+
+// Helper function for returning address or abstract of Chainlog
+//  Valid on Mainnet, Kovan, Rinkeby, Ropsten, and Goerli
+contract ChainlogHelper {
+    address          public constant ADDRESS  = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+    ChainlogAbstract public constant ABSTRACT = ChainlogAbstract(ADDRESS);
+}

--- a/src/interfaces/DSChiefAbstract.sol
+++ b/src/interfaces/DSChiefAbstract.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/dapphub/ds-chief
+interface DSChiefAbstract {
+    function live() external view returns (uint256);
+    function launch() external;
+    function slates(bytes32) external view returns (address[] memory);
+    function votes(address) external view returns (bytes32);
+    function approvals(address) external view returns (uint256);
+    function deposits(address) external view returns (address);
+    function GOV() external view returns (address);
+    function IOU() external view returns (address);
+    function hat() external view returns (address);
+    function MAX_YAYS() external view returns (uint256);
+    function lock(uint256) external;
+    function free(uint256) external;
+    function etch(address[] calldata) external returns (bytes32);
+    function vote(address[] calldata) external returns (bytes32);
+    function vote(bytes32) external;
+    function lift(address) external;
+    function setOwner(address) external;
+    function setAuthority(address) external;
+    function isUserRoot(address) external view returns (bool);
+    function setRootUser(address, bool) external;
+    function _root_users(address) external view returns (bool);
+    function _user_roles(address) external view returns (bytes32);
+    function _capability_roles(address, bytes4) external view returns (bytes32);
+    function _public_capabilities(address, bytes4) external view returns (bool);
+    function getUserRoles(address) external view returns (bytes32);
+    function getCapabilityRoles(address, bytes4) external view returns (bytes32);
+    function isCapabilityPublic(address, bytes4) external view returns (bool);
+    function hasUserRole(address, uint8) external view returns (bool);
+    function canCall(address, address, bytes4) external view returns (bool);
+    function setUserRole(address, uint8, bool) external;
+    function setPublicCapability(address, bytes4, bool) external;
+    function setRoleCapability(uint8, address, bytes4, bool) external;
+}
+
+interface DSChiefFabAbstract {
+    function newChief(address, uint256) external returns (address);
+}

--- a/src/interfaces/DSPauseAbstract.sol
+++ b/src/interfaces/DSPauseAbstract.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/dapphub/ds-pause
+interface DSPauseAbstract {
+    function owner() external view returns (address);
+    function authority() external view returns (address);
+    function setOwner(address) external;
+    function setAuthority(address) external;
+    function setDelay(uint256) external;
+    function plans(bytes32) external view returns (bool);
+    function proxy() external view returns (address);
+    function delay() external view returns (uint256);
+    function plot(address, bytes32, bytes calldata, uint256) external;
+    function drop(address, bytes32, bytes calldata, uint256) external;
+    function exec(address, bytes32, bytes calldata, uint256) external returns (bytes memory);
+}

--- a/src/interfaces/DSSpellAbstract.sol
+++ b/src/interfaces/DSSpellAbstract.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/dapphub/ds-spell
+interface DSSpellAbstract {
+    function whom() external view returns (address);
+    function mana() external view returns (uint256);
+    function data() external view returns (bytes memory);
+    function done() external view returns (bool);
+    function cast() external;
+}

--- a/src/interfaces/DSTokenAbstract.sol
+++ b/src/interfaces/DSTokenAbstract.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/dapphub/ds-token/blob/master/src/token.sol
+interface DSTokenAbstract {
+    function name() external view returns (bytes32);
+    function symbol() external view returns (bytes32);
+    function decimals() external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address) external view returns (uint256);
+    function transfer(address, uint256) external returns (bool);
+    function allowance(address, address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
+    function approve(address) external returns (bool);
+    function transferFrom(address, address, uint256) external returns (bool);
+    function push(address, uint256) external;
+    function pull(address, uint256) external;
+    function move(address, address, uint256) external;
+    function mint(uint256) external;
+    function mint(address,uint) external;
+    function burn(uint256) external;
+    function burn(address,uint) external;
+    function setName(bytes32) external;
+    function authority() external view returns (address);
+    function owner() external view returns (address);
+    function setOwner(address) external;
+    function setAuthority(address) external;
+}

--- a/src/interfaces/DSValueAbstract.sol
+++ b/src/interfaces/DSValueAbstract.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/dapphub/ds-value/blob/master/src/value.sol
+interface DSValueAbstract {
+    function has() external view returns (bool);
+    function val() external view returns (bytes32);
+    function peek() external view returns (bytes32, bool);
+    function read() external view returns (bytes32);
+    function poke(bytes32) external;
+    function void() external;
+    function authority() external view returns (address);
+    function owner() external view returns (address);
+    function setOwner(address) external;
+    function setAuthority(address) external;
+}

--- a/src/interfaces/DaiAbstract.sol
+++ b/src/interfaces/DaiAbstract.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/dai.sol
+interface DaiAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function version() external view returns (string memory);
+    function decimals() external view returns (uint8);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address) external view returns (uint256);
+    function allowance(address, address) external view returns (uint256);
+    function nonces(address) external view returns (uint256);
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function PERMIT_TYPEHASH() external view returns (bytes32);
+    function transfer(address, uint256) external returns (bool);
+    function transferFrom(address, address, uint256) external returns (bool);
+    function mint(address, uint256) external;
+    function burn(address, uint256) external;
+    function approve(address, uint256) external returns (bool);
+    function push(address, uint256) external;
+    function pull(address, uint256) external;
+    function move(address, address, uint256) external;
+    function permit(address, address, uint256, uint256, bool, uint8, bytes32, bytes32) external;
+}

--- a/src/interfaces/DaiJoinAbstract.sol
+++ b/src/interfaces/DaiJoinAbstract.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/join.sol
+interface DaiJoinAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address usr) external;
+    function deny(address usr) external;
+    function vat() external view returns (address);
+    function dai() external view returns (address);
+    function live() external view returns (uint256);
+    function cage() external;
+    function join(address, uint256) external;
+    function exit(address, uint256) external;
+}

--- a/src/interfaces/EndAbstract.sol
+++ b/src/interfaces/EndAbstract.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/end.sol
+interface EndAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function vat() external view returns (address);
+    function cat() external view returns (address);
+    function dog() external view returns (address);
+    function vow() external view returns (address);
+    function pot() external view returns (address);
+    function spot() external view returns (address);
+    function live() external view returns (uint256);
+    function when() external view returns (uint256);
+    function wait() external view returns (uint256);
+    function debt() external view returns (uint256);
+    function tag(bytes32) external view returns (uint256);
+    function gap(bytes32) external view returns (uint256);
+    function Art(bytes32) external view returns (uint256);
+    function fix(bytes32) external view returns (uint256);
+    function bag(address) external view returns (uint256);
+    function out(bytes32, address) external view returns (uint256);
+    function WAD() external view returns (uint256);
+    function RAY() external view returns (uint256);
+    function file(bytes32, address) external;
+    function file(bytes32, uint256) external;
+    function cage() external;
+    function cage(bytes32) external;
+    function skip(bytes32, uint256) external;
+    function snip(bytes32, uint256) external;
+    function skim(bytes32, address) external;
+    function free(bytes32) external;
+    function thaw() external;
+    function flow(bytes32) external;
+    function pack(uint256) external;
+    function cash(bytes32, uint256) external;
+}

--- a/src/interfaces/FlipAbstract.sol
+++ b/src/interfaces/FlipAbstract.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/flip.sol
+interface FlipAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address usr) external;
+    function deny(address usr) external;
+    function bids(uint256) external view returns (uint256, uint256, address, uint48, uint48, address, address, uint256);
+    function vat() external view returns (address);
+    function cat() external view returns (address);
+    function ilk() external view returns (bytes32);
+    function beg() external view returns (uint256);
+    function ttl() external view returns (uint48);
+    function tau() external view returns (uint48);
+    function kicks() external view returns (uint256);
+    function file(bytes32, uint256) external;
+    function kick(address, address, uint256, uint256, uint256) external returns (uint256);
+    function tick(uint256) external;
+    function tend(uint256, uint256, uint256) external;
+    function dent(uint256, uint256, uint256) external;
+    function deal(uint256) external;
+    function yank(uint256) external;
+}

--- a/src/interfaces/FlipperMomAbstract.sol
+++ b/src/interfaces/FlipperMomAbstract.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/flipper-mom/blob/master/src/FlipperMom.sol
+interface FlipperMomAbstract {
+    function owner() external view returns (address);
+    function authority() external view returns (address);
+    function setOwner(address) external;
+    function setAuthority(address) external;
+    function cat() external returns (address);
+    function rely(address) external;
+    function deny(address) external;
+}

--- a/src/interfaces/GemJoinAbstract.sol
+++ b/src/interfaces/GemJoinAbstract.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/join.sol
+interface GemJoinAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function vat() external view returns (address);
+    function ilk() external view returns (bytes32);
+    function gem() external view returns (address);
+    function dec() external view returns (uint256);
+    function live() external view returns (uint256);
+    function cage() external;
+    function join(address, uint256) external;
+    function exit(address, uint256) external;
+}

--- a/src/interfaces/IlkRegistryAbstract.sol
+++ b/src/interfaces/IlkRegistryAbstract.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/ilk-registry
+interface IlkRegistryAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function vat() external view returns (address);
+    function dog() external view returns (address);
+    function cat() external view returns (address);
+    function spot() external view returns (address);
+    function ilkData(bytes32) external view returns (
+        uint96, address, address, uint8, uint96, address, address, string memory, string memory
+    );
+    function ilks() external view returns (bytes32[] memory);
+    function ilks(uint) external view returns (bytes32);
+    function add(address) external;
+    function remove(bytes32) external;
+    function update(bytes32) external;
+    function removeAuth(bytes32) external;
+    function file(bytes32, address) external;
+    function file(bytes32, bytes32, address) external;
+    function file(bytes32, bytes32, uint256) external;
+    function file(bytes32, bytes32, string calldata) external;
+    function count() external view returns (uint256);
+    function list() external view returns (bytes32[] memory);
+    function list(uint256, uint256) external view returns (bytes32[] memory);
+    function get(uint256) external view returns (bytes32);
+    function info(bytes32) external view returns (
+        string memory, string memory, uint256, uint256, address, address, address, address
+    );
+    function pos(bytes32) external view returns (uint256);
+    function class(bytes32) external view returns (uint256);
+    function gem(bytes32) external view returns (address);
+    function pip(bytes32) external view returns (address);
+    function join(bytes32) external view returns (address);
+    function xlip(bytes32) external view returns (address);
+    function dec(bytes32) external view returns (uint256);
+    function symbol(bytes32) external view returns (string memory);
+    function name(bytes32) external view returns (string memory);
+    function put(bytes32, address, address, uint256, uint256, address, address, string calldata, string calldata) external;
+}

--- a/src/interfaces/JugAbstract.sol
+++ b/src/interfaces/JugAbstract.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/jug.sol
+interface JugAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function ilks(bytes32) external view returns (uint256, uint256);
+    function vat() external view returns (address);
+    function vow() external view returns (address);
+    function base() external view returns (uint256);
+    function init(bytes32) external;
+    function file(bytes32, bytes32, uint256) external;
+    function file(bytes32, uint256) external;
+    function file(bytes32, address) external;
+    function drip(bytes32) external returns (uint256);
+}

--- a/src/interfaces/OsmMomAbstract.sol
+++ b/src/interfaces/OsmMomAbstract.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/osm-mom
+interface OsmMomAbstract {
+    function owner() external view returns (address);
+    function authority() external view returns (address);
+    function osms(bytes32) external view returns (address);
+    function setOsm(bytes32, address) external;
+    function setOwner(address) external;
+    function setAuthority(address) external;
+    function stop(bytes32) external;
+}

--- a/src/interfaces/PotAbstract.sol
+++ b/src/interfaces/PotAbstract.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/pot.sol
+interface PotAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function pie(address) external view returns (uint256);
+    function Pie() external view returns (uint256);
+    function dsr() external view returns (uint256);
+    function chi() external view returns (uint256);
+    function vat() external view returns (address);
+    function vow() external view returns (address);
+    function rho() external view returns (uint256);
+    function live() external view returns (uint256);
+    function file(bytes32, uint256) external;
+    function file(bytes32, address) external;
+    function cage() external;
+    function drip() external returns (uint256);
+    function join(uint256) external;
+    function exit(uint256) external;
+}

--- a/src/interfaces/SpotAbstract.sol
+++ b/src/interfaces/SpotAbstract.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/spot.sol
+interface SpotAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function ilks(bytes32) external view returns (address, uint256);
+    function vat() external view returns (address);
+    function par() external view returns (uint256);
+    function live() external view returns (uint256);
+    function file(bytes32, bytes32, address) external;
+    function file(bytes32, uint256) external;
+    function file(bytes32, bytes32, uint256) external;
+    function poke(bytes32) external;
+    function cage() external;
+}

--- a/src/interfaces/VatAbstract.sol
+++ b/src/interfaces/VatAbstract.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/vat.sol
+interface VatAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address) external;
+    function deny(address) external;
+    function can(address, address) external view returns (uint256);
+    function hope(address) external;
+    function nope(address) external;
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256);
+    function urns(bytes32, address) external view returns (uint256, uint256);
+    function gem(bytes32, address) external view returns (uint256);
+    function dai(address) external view returns (uint256);
+    function sin(address) external view returns (uint256);
+    function debt() external view returns (uint256);
+    function vice() external view returns (uint256);
+    function Line() external view returns (uint256);
+    function live() external view returns (uint256);
+    function init(bytes32) external;
+    function file(bytes32, uint256) external;
+    function file(bytes32, bytes32, uint256) external;
+    function cage() external;
+    function slip(bytes32, address, int256) external;
+    function flux(bytes32, address, address, uint256) external;
+    function move(address, address, uint256) external;
+    function frob(bytes32, address, address, address, int256, int256) external;
+    function fork(bytes32, address, address, int256, int256) external;
+    function grab(bytes32, address, address, address, int256, int256) external;
+    function heal(uint256) external;
+    function suck(address, address, uint256) external;
+    function fold(bytes32, address, int256) external;
+}

--- a/src/interfaces/VowAbstract.sol
+++ b/src/interfaces/VowAbstract.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.5.12;
+
+// https://github.com/makerdao/dss/blob/master/src/vow.sol
+interface VowAbstract {
+    function wards(address) external view returns (uint256);
+    function rely(address usr) external;
+    function deny(address usr) external;
+    function vat() external view returns (address);
+    function flapper() external view returns (address);
+    function flopper() external view returns (address);
+    function sin(uint256) external view returns (uint256);
+    function Sin() external view returns (uint256);
+    function Ash() external view returns (uint256);
+    function wait() external view returns (uint256);
+    function dump() external view returns (uint256);
+    function sump() external view returns (uint256);
+    function bump() external view returns (uint256);
+    function hump() external view returns (uint256);
+    function live() external view returns (uint256);
+    function file(bytes32, uint256) external;
+    function file(bytes32, address) external;
+    function fess(uint256) external;
+    function flog(uint256) external;
+    function heal(uint256) external;
+    function kiss(uint256) external;
+    function flop() external returns (uint256);
+    function flap() external returns (uint256);
+    function cage() external;
+}

--- a/src/test/RwaSpell.t.sol
+++ b/src/test/RwaSpell.t.sol
@@ -26,9 +26,26 @@ import "ds-value/value.sol";
 
 import "ds-math/math.sol";
 import "ds-test/test.sol";
-import "dss-interfaces/Interfaces.sol";
 import "./rates.sol";
 import "./addresses_kovan.sol";
+import "../interfaces/ChainlogAbstract.sol";
+import "../interfaces/EndAbstract.sol";
+import "../interfaces/DSPauseAbstract.sol";
+import "../interfaces/VatAbstract.sol";
+import "../interfaces/DSChiefAbstract.sol";
+import "../interfaces/DSValueAbstract.sol";
+import "../interfaces/CatAbstract.sol";
+import "../interfaces/JugAbstract.sol";
+import "../interfaces/VowAbstract.sol";
+import "../interfaces/PotAbstract.sol";
+import "../interfaces/SpotAbstract.sol";
+import "../interfaces/DSTokenAbstract.sol";
+import "../interfaces/IlkRegistryAbstract.sol";
+import "../interfaces/OsmMomAbstract.sol";
+import "../interfaces/FlipperMomAbstract.sol";
+import "../interfaces/FlipAbstract.sol";
+import "../interfaces/GemJoinAbstract.sol";
+import "../interfaces/DSSpellAbstract.sol";
 
 import {RwaSpell, SpellAction} from "../RwaSpell.sol";
 


### PR DESCRIPTION
In order to reduce the pain of dependency mismatch, this pr removes dss-interfaces from this repo in favor of static interfaces.

This could probably be further optimized by using pared down local interfaces instead of imports in the future.